### PR TITLE
Remove check for avatar bundle size in AvatarUploader.cs

### DIFF
--- a/Editor/Scripts/AvatarUploader.cs
+++ b/Editor/Scripts/AvatarUploader.cs
@@ -158,17 +158,6 @@ namespace EAUploader
                         return;
                     }
 
-                    if (ValidationHelpers.CheckIfAssetBundleFileTooLarge(ContentType.Avatar, bundlePath, out int fileSize,
-                            VRC.Tools.Platform != "standalonewindows"))
-                    {
-                        var limit = ValidationHelpers.GetAssetBundleSizeLimit(ContentType.Avatar,
-                            VRC.Tools.Platform != "standalonewindows");
-
-                        OnDialogRequired("Upload Failed",
-                            T7e.Get("Avatar bundle size is too large. The maximum size is {0} MB, but the current size is {1} MB",
-                                     limit, fileSize));
-                    }
-
                     if (!selectedPrefab.TryGetComponent<PipelineManager>(out var pM))
                     {
                         OnDialogRequired("Upload Failed", T7e.Get("Prefab does not contain a PipelineManager component"));


### PR DESCRIPTION
This pull request removes the check for avatar bundle size in the AvatarUploader.cs file. The check was causing issues and is no longer necessary.

close #41