### PR TITLE
Fix rendering prefab preview etc

### DIFF
--- a/Editor/Resources/UI/TabContents/ImportSettings/Contents/ManageModels.cs
+++ b/Editor/Resources/UI/TabContents/ImportSettings/Contents/ManageModels.cs
@@ -1,6 +1,7 @@
 ﻿using EAUploader.Components;
 using EAUploader.CustomPrefabUtility;
 using EAUploader.UI.Components;
+using EAUploader.UI.Windows;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -259,7 +260,7 @@ namespace EAUploader.UI.ImportSettings
                 previewImage.image = prefab.Preview;
             }
 
-            previewImage.RegisterCallback<MouseUpEvent>(evt => ShowLargeImage(prefab.Preview));
+            previewImage.RegisterCallback<MouseUpEvent>(evt => ShowLargeImage(prefab));
 
             var name = this.Q<Label>("nameLabel");
             name.text = prefab.Name;
@@ -374,16 +375,9 @@ namespace EAUploader.UI.ImportSettings
             deleteButton.clicked += () => DeletePrefab(prefab.Path);
         }
 
-        private static void ShowLargeImage(Texture2D image)
+        private static void ShowLargeImage(PrefabInfo prefab)
         {
-            var window = ScriptableObject.CreateInstance<EditorWindow>();
-            window.titleContent = new GUIContent(UnityEditor.L10n.Tr("Preview"));
-            window.minSize = new Vector2(500, 500);
-
-            var preview = new Image { image = image, style = { flexGrow = 1 } };
-            window.rootVisualElement.Add(preview);
-
-            window.Show();
+            PrefabPreviewer.ShowLargeImage(prefab.Path, prefab.Preview);
         }
 
         internal static void ChangePrefabName(string prefabPath)

--- a/Editor/Resources/UI/TabContents/Setup/Editor/ViewpointPositionEditor/Localization/ja.json
+++ b/Editor/Resources/UI/TabContents/Setup/Editor/ViewpointPositionEditor/Localization/ja.json
@@ -28,6 +28,18 @@
     {
       "key": "Import extentions",
       "value": "拡張機能をインポート"
+    },
+    {
+      "key": "Regenerate Preview",
+      "value": "プレビューを再生成する"
+    },
+    {
+      "key": "Change the thumbnail of list",
+      "value": "リストのサムネイルの変更"
+    },
+    {
+      "key": "Do you also change the thumbnails that appear in the EAUploader avatar list?",
+      "value": "EAUplaoderのアバターリストのサムネイルにも適用しますか？"
     }
   ]
 }

--- a/Editor/Resources/UI/TabContents/Setup/Editor/ViewpointPositionEditor/Localization/ko.json
+++ b/Editor/Resources/UI/TabContents/Setup/Editor/ViewpointPositionEditor/Localization/ko.json
@@ -28,6 +28,18 @@
     {
       "key": "Import extentions",
       "value": "확장 기능 가져오기"
+    },
+    {
+      "key": "Regenerate Preview",
+      "value": "미리보기 재생성하기"
+    },
+    {
+      "key": "Change the thumbnail of list",
+      "value": "목록 썸네일 변경"
+    },
+    {
+      "key": "Do you also change the thumbnails that appear in the EAUploader avatar list?",
+      "value": "EAUplaoder의 아바타 목록의 썸네일에도 적용할 수 있나요?"
     }
   ]
 }

--- a/Editor/Resources/UI/TabContents/Upload/Contents/UploadForm.cs
+++ b/Editor/Resources/UI/TabContents/Upload/Contents/UploadForm.cs
@@ -292,6 +292,11 @@ namespace EAUploader.UI.Upload
                 texture.LoadImage(File.ReadAllBytes(path));
                 avatarThumbnail.image = texture;
                 thumbnailUrl = path;
+                
+                if(EditorUtility.DisplayDialog(T7e.Get("Change the thumbnail of list"), T7e.Get("Do you also change the thumbnails that appear in the EAUploader avatar list?"), T7e.Get("Yes"), T7e.Get("No")))
+                {
+                    PrefabPreview.SavePrefabPreview(EAUploaderCore.selectedPrefabPath, texture);
+                }
             }
         }
 

--- a/Editor/Resources/UI/Windows/PrefabPreviewer.cs
+++ b/Editor/Resources/UI/Windows/PrefabPreviewer.cs
@@ -1,0 +1,87 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using EAUploader;
+using EAUploader.UI.Components;
+using EAUploader.CustomPrefabUtility;
+
+namespace EAUploader.UI.Windows
+{
+    public class PrefabPreviewer : EditorWindow
+    {
+        private static PrefabPreviewer previewWindow;
+        private string prefabPath;
+        private Image preview;
+        private static Texture2D _image;
+
+        public static void ShowLargeImage(string prefabPath, Texture2D image)
+        {
+            _image = image;
+
+            if (previewWindow == null)
+            {
+                previewWindow = CreateInstance<PrefabPreviewer>();
+                previewWindow.titleContent = new GUIContent(UnityEditor.L10n.Tr("Preview"));
+                previewWindow.minSize = new Vector2(500, 500);
+                previewWindow.prefabPath = prefabPath;
+                previewWindow.CreateGUI();
+                previewWindow.UpdatePreview();
+                previewWindow.Show();
+            }
+            else
+            {
+                if (previewWindow.titleContent.text == UnityEditor.L10n.Tr("Preview"))
+                {
+                    previewWindow.Focus();
+                    previewWindow.prefabPath = prefabPath;
+                    if (previewWindow.preview == null)
+                    {
+                        previewWindow.CreateGUI();
+                    }
+                    previewWindow.UpdatePreview();
+                }
+                else
+                {
+                    previewWindow = null;
+                    ShowLargeImage(prefabPath, image);
+                }
+            }
+        }
+
+        private void CreateGUI()
+        {
+            rootVisualElement.Clear();
+
+            var visualTree = Resources.Load<VisualTreeAsset>("UI/Windows/PrefabPreviewer");
+            visualTree.CloneTree(rootVisualElement);
+
+            rootVisualElement.styleSheets.Add(EAUploader.styles);
+            rootVisualElement.styleSheets.Add(EAUploader.tailwind);
+
+            preview = rootVisualElement.Q<Image>("preview");
+            preview.image = _image;
+
+            var regenerateButton = rootVisualElement.Q<ShadowButton>("regenerate");
+            regenerateButton.clicked += RegeneratePreview;
+
+            LanguageUtility.Localization(rootVisualElement);
+        }
+
+        private void UpdatePreview()
+        {
+            preview.image = _image;
+        }
+
+        private void RegeneratePreview()
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefab != null)
+            {
+                Texture2D previewTexture = PrefabPreview.GeneratePreview(prefab);
+                _image = previewTexture;
+                UpdatePreview();
+                PrefabPreview.SavePrefabPreview(prefabPath, previewTexture);
+            }
+        }
+    }
+}

--- a/Editor/Resources/UI/Windows/PrefabPreviewer.cs.meta
+++ b/Editor/Resources/UI/Windows/PrefabPreviewer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e73c17321467e124997301a615df7420
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/UI/Windows/PrefabPreviewer.uxml
+++ b/Editor/Resources/UI/Windows/PrefabPreviewer.uxml
@@ -1,0 +1,17 @@
+<ui:UXML
+    xmlns:ui="UnityEngine.UIElements"
+    xmlns:uie="UnityEditor.UIElements"
+    xmlns:eau="EAUploader.UI.Components"
+    xsi="http://www.w3.org/2001/XMLSchema-instance"
+    engine="UnityEngine.UIElements"
+    editor="UnityEditor.UIElements"
+    noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd"
+    editor-extension-mode="True"
+>
+    <ui:VisualElement class="flex-1 flex-col">
+        <ui:Image name="preview" class="flex-1"/>
+        <ui:VisualElement class="flex-row justify-end p-2">
+            <eau:ShadowButton name="regenerate" text="Regenerate Preview" class="mr-2"/>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/Resources/UI/Windows/PrefabPreviewer.uxml.meta
+++ b/Editor/Resources/UI/Windows/PrefabPreviewer.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 62bd9603fe6291f4b9d944a6a3d7f151
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
Resolve #113 
* プレビュー生成を修正　バウンズが大きい場合もプレビューが生成されるよう修正（ただし改善の余地あり）
* PrefabPreviewerをUI.Windows名前空間に移動
* PrefabPreviewerにプレビュー再生成ボタンを追加
* PrefabPreviewクラスにプレビューがあるか確認するIsPrefabPreviewExistメソッドを追加
* GenerateAndSaveAllPrefabPreviewsにて既にプレビューがある場合は生成をスキップするように変更
* UploadFormでサムネイル変更時にPrefabのプレビューも変更するか確認するダイヤログを追加