### PR TITLE
Hotfix/#239

### DIFF
--- a/Editor/Resources/UI/EAUploader.cs
+++ b/Editor/Resources/UI/EAUploader.cs
@@ -8,13 +8,39 @@ namespace EAUploader.UI
 {
     public class EAUploader : EditorWindow
     {
+        private static EAUploader instance;
+
+        public static EAUploader Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = GetWindow<EAUploader>();
+                }
+                return instance;
+            }
+        }
+
+        private void OnEnable()
+        {
+            instance = this;
+        }
+
+        private void OnDisable()
+        {
+            instance = null;
+        }
+
         [MenuItem("EAUploader/Open EAUploader")]
         public static void ShowWindow()
         {
-            EAUploader wnd = GetWindow<EAUploader>();
-            wnd.titleContent = new GUIContent("EAUploader");
-            wnd.position = new Rect(100, 100, 1280, 640);
-            wnd.minSize = new Vector2(1080, 640);
+            EAUploader window = Instance;
+            window.titleContent = new GUIContent("EAUploader");
+            window.position = new Rect(100, 100, 1280, 640);
+            window.minSize = new Vector2(1080, 640);
+            window.Show();
+            window.Focus();
         }
 
         private VisualElement contentRoot = null;

--- a/Editor/Resources/UI/TabContents/ImportSettings/Contents/Import.cs
+++ b/Editor/Resources/UI/TabContents/ImportSettings/Contents/Import.cs
@@ -246,7 +246,7 @@ namespace EAUploader.UI.ImportSettings
 
         private static void ApplyTheme(string theme)
         {
-            var root = EditorWindow.GetWindow<EAUploader>().rootVisualElement;
+            var root = EAUploader.Instance.rootVisualElement;
             root.RemoveFromClassList("white");
             root.RemoveFromClassList("dark");
             root.AddToClassList(theme);

--- a/Editor/Resources/UI/Windows/DialogPro.cs
+++ b/Editor/Resources/UI/Windows/DialogPro.cs
@@ -43,7 +43,7 @@ namespace EAUploader.UI.Windows
                 return; // 既にウィンドウが開いている場合は新しいウィンドウを開かない
             }
 
-            var eauWindow = GetWindow<EAUploader>(null, focus: false);
+            var eauWindow = EAUploader.Instance;
             DialogPro wnd = CreateInstance<DialogPro>();
             wnd.titleContent = new GUIContent(title);
             wnd.position = new Rect(eauWindow.position.x + eauWindow.position.width / 2 - 200, eauWindow.position.y + eauWindow.position.height / 2 - 100, 400, 200);
@@ -110,7 +110,7 @@ namespace EAUploader.UI.Windows
                 return; // 既にウィンドウが開いている場合は新しいウィンドウを開かない
             }
 
-            var eauWindow = GetWindow<EAUploader>(null, focus: false);
+            var eauWindow = EAUploader.Instance;
             DialogPro wnd = CreateInstance<DialogPro>();
             wnd.titleContent = new GUIContent(title);
             wnd.position = new Rect(eauWindow.position.x + eauWindow.position.width / 2 - 200, eauWindow.position.y + eauWindow.position.height / 2 - 100, 400, 200);
@@ -161,6 +161,7 @@ namespace EAUploader.UI.Windows
             }
 
             wnd.Show();
+            wnd.Focus();
         }
     }
 }

--- a/Editor/Resources/UI/Windows/Logger.cs
+++ b/Editor/Resources/UI/Windows/Logger.cs
@@ -13,6 +13,31 @@ namespace EAUploader.UI.Windows
 {
     public class Logger : EditorWindow
     {
+        private static Logger instance;
+
+        public static Logger Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = GetWindow<Logger>();
+                }
+                return instance;
+            }
+        }
+
+        internal void OnEnable()
+        {
+            instance = this;
+            _stringBuilder = new StringBuilder();
+        }
+
+        private void OnDisable()
+        {
+            instance = null;
+        }
+
 
         /// <summary>
         /// EAUploaderのログ出力において使用するログ種別。
@@ -81,12 +106,6 @@ namespace EAUploader.UI.Windows
             Debug.LogError("This is a test error message");
         }
 
-        internal void OnEnable()
-        {
-            _stringBuilder = new StringBuilder();
-        }
-
-
         public static string GetLogFolderFullPath()
         {
             return new DirectoryInfo(LOGFOLDER_PATH).FullName;
@@ -130,8 +149,8 @@ namespace EAUploader.UI.Windows
 
             if (logType == LogType.Exception || logType == LogType.Error)
             {
-                var eauWindow = GetWindow<UI.EAUploader>(null, focus: false);
-                Logger wnd = GetWindow<Logger>();
+                var eauWindow = UI.EAUploader.Instance;
+                Logger wnd = Instance;
                 wnd.titleContent = new GUIContent(T7e.Get("Error Report"));
                 wnd.position = new Rect(eauWindow.position.x + eauWindow.position.width / 2 - 400, eauWindow.position.y + eauWindow.position.height / 2 - 300, 800, 600);
                 wnd.minSize = new Vector2(800, 600);

--- a/Editor/Scripts/EAUploaderCore.cs
+++ b/Editor/Scripts/EAUploaderCore.cs
@@ -165,23 +165,9 @@ namespace EAUploader
 
         private static void OpenEAUploaderWindow()
         {
-            // 既存のウィンドウを検索
-            var windows = Resources.FindObjectsOfTypeAll<EditorWindow>()
-                .Where(window => window.GetType().Name == "EAUploader").ToList();
-
-            Debug.Log($"EAUploader windows found: {windows.Count}");
-
-            if (windows.Count == 0)
-            {
-                Debug.Log("Attempting to open EAUploader...");
-                bool result = EditorApplication.ExecuteMenuItem("EAUploader/Open EAUploader");
-                Debug.Log($"EAUploader opened: {result}");
-            }
-            else
-            {
-                Debug.Log("Focusing on existing EAUploader window.");
-                windows[0].Focus();
-            }
+            UI.EAUploader window = UI.EAUploader.Instance;
+            window.Show();
+            window.Focus();
         }
 
         public static string GetVersion(bool noText = false)


### PR DESCRIPTION
fix #239
シングルトンを採用しEAUploader, LoggerのWindowのインスタンスが1つだけというのを保証するようにしました。
EAUploaderのシングルトンにより初期起動時のパフォーマンスが多少向上

まだ、白いWindowが出てしまう場合はタスクマネージャーで消すことができます。
Unity Editor -> [自分の今開いてるプロジェクトの名前が入ってないプログラム]をタスクキルすることによって消すことができます。

検証はしていないが、作業を始める前にWindow/Layouts/Defaultを選択してEAUploaderを起動したら白いWindowが表示されないかもしれないです。